### PR TITLE
Fix Digest deprecation warning in the Ruby client

### DIFF
--- a/Ruby/lib/semantria/authrequest.rb
+++ b/Ruby/lib/semantria/authrequest.rb
@@ -145,7 +145,7 @@ class AuthRequest
   end
 
   def get_sha1(md5cs, query)
-    digest = OpenSSL::Digest::Digest.new('sha1')
+    digest = OpenSSL::Digest.new('sha1')
     # our composite signing key now has the token secret after the ampersand
     sha1res = OpenSSL::HMAC.digest(digest, md5cs, query)
     Base64.encode64(sha1res).chomp.gsub(/\n/, '')


### PR DESCRIPTION
The previous version causes this deprecation warning:

```
Digest::Digest is deprecated; use Digest
```

See:
 * https://github.com/ruby/ruby/pull/446
 * http://stackoverflow.com/questions/21184960/ruby-digestdigest-is-deprecated-use-digest