### PR TITLE
Updated pom.xml to ignore compilation of tests.

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>SemantriaJavaSDK</artifactId>
     <version>3.5.75</version>
 
+    <properties>
+         <skipTests>true</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -34,10 +38,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
-                        <test>
-                            SerializerTest
-                        </test>
-                    <!--<skipTests>true</skipTests>-->
+                    <skipTests>${skipTests}</skipTests>
                 </configuration>
             </plugin>
             <plugin>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -8,8 +8,8 @@
     <artifactId>SemantriaJavaSDK</artifactId>
     <version>3.5.75</version>
 
-    <properties>
-         <skipTests>true</skipTests>
+     <properties>
+       <maven.test.skip>true</maven.test.skip>
     </properties>
 
     <dependencies>
@@ -38,7 +38,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
-                    <skipTests>${skipTests}</skipTests>
+                    <!--<skipTests>${skipTests}</skipTests>-->
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Added skipTests property to ignore compilation of SessionTest.java which was failing with the following error message:

Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project SemantriaJavaSDK: No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.) -> [Help 1]

Tests can still be compiled and specified by using the command-line.  See (http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-test.html) for more information